### PR TITLE
mail/p5-Mail-Milter-Authentication: various fixes

### DIFF
--- a/mail/p5-Mail-Milter-Authentication/Makefile
+++ b/mail/p5-Mail-Milter-Authentication/Makefile
@@ -47,10 +47,25 @@ TEST_DEPENDS=	p5-Crypt-OpenSSL-RSA>0:security/p5-Crypt-OpenSSL-RSA \
 		p5-Test-Exception>0:devel/p5-Test-Exception \
 		p5-Test-Perl-Critic>0:textproc/p5-Test-Perl-Critic
 
-USES=		perl5
+USES=		perl5 shebangfix
 USE_PERL5=	configure
 USE_RC_SUBR=	authentication_milter
+SHEBANG_FILES=	bin/authentication_milter \
+		bin/authentication_milter_blocker \
+		bin/authentication_milter_client \
+		bin/authentication_milter_log
 
+NO_ARCH=	yes
+EXTRACT_AFTER_ARGS= \
+		--exclude ./share/authentication_milter.init \
+		--no-same-owner --no-same-permission
+SUB_FILES=	pkg-message
+.for V in CACHEDIR ETCDIR LOGDIR RUNDIR SPOOLDIR VARLIBDIR VARLIBDIRBASE \
+    DEFAULT_USER DEFAULT_GROUP
+SUB_LIST+=	${V}=${$V}
+REINPLACE_ARGS+=	-e "s|%%${V}%%|${$V}|g"
+.endfor
+PLIST_SUB=	${SUB_LIST}
 TEST_ENV=	AUTHOR_TESTING=1 \
 		RELEASE_TESTING=1 \
 		TEST_AUTHOR=1
@@ -60,45 +75,19 @@ ETCDIR=		${PREFIX}/etc/mail
 LOGDIR=		/var/log
 RUNDIR=		/var/run/auth_milter
 SPOOLDIR=	/var/spool/auth_milter
+VARLIBDIRBASE=	/var/lib
 VARLIBDIR=	/var/lib/auth_milter
 DEFAULT_USER=	mailnull
 DEFAULT_GROUP=	mailnull
 
-NO_ARCH=	yes
-SUB_FILES=	pkg-message
-SUB_LIST=	CACHEDIR=${CACHEDIR} \
-		LOGDIR=${LOGDIR} \
-		RUNDIR=${RUNDIR} \
-		SPOOLDIR=${SPOOLDIR} \
-		VARLIBDIR=${VARLIBDIR}
-SUB_LIST+=	DEFAULT_GROUP=${DEFAULT_GROUP} \
-		DEFAULT_USER=${DEFAULT_USER}
-PLIST_SUB=	${SUB_LIST}
-
-post-extract:
-		${RM} ${WRKSRC}/share/authentication_milter.init
-
 post-patch:
-		${REINPLACE_CMD} \
-			-e "s|%%CACHEDIR%%|${CACHEDIR}|g" \
-			-e "s|%%ETCDIR%%|${ETCDIR}|g" \
-			-e "s|%%LOGDIR%%|${LOGDIR}|g" \
-			-e "s|%%PREFIX%%|${PREFIX}|g" \
-			-e "s|%%RUNDIR%%|${RUNDIR}|g" \
-			-e "s|%%SPOOLDIR%%|${SPOOLDIR}|g" \
-			-e "s|%%VARLIBDIR%%|${VARLIBDIR}|g" \
-			-e "s|%%DEFAULT_USER%%|${DEFAULT_USER}|g" \
-			-e "s|%%DEFAULT_GROUP%%|${DEFAULT_GROUP}|g" \
-			${PATCH_WRKSRC}/bin/authentication_milter \
-			${PATCH_WRKSRC}/lib/Mail/Milter/Authentication/Config.pm \
-			${PATCH_WRKSRC}/lib/Mail/Milter/Authentication/Handler/DMARC.pm \
-			${PATCH_WRKSRC}/share/authentication_milter.json
+		cd ${PATCH_WRKSRC} && ${REINPLACE_CMD} ${REINPLACE_ARGS} \
+		    bin/authentication_milter \
+		    lib/Mail/Milter/Authentication/Config.pm \
+		    lib/Mail/Milter/Authentication/Handler/DMARC.pm \
+		    share/authentication_milter.json
 
 post-install:
-		${MKDIR} ${STAGEDIR}${RUNDIR} \
-			 ${STAGEDIR}${CACHEDIR} \
-			 ${STAGEDIR}${SPOOLDIR} \
-			 ${STAGEDIR}${VARLIBDIR} \
-			 ${STAGEDIR}${ETCDIR}/authentication_milter.d
+		${MKDIR} ${STAGEDIR}${ETCDIR}/authentication_milter.d
 
 .include <bsd.port.mk>

--- a/mail/p5-Mail-Milter-Authentication/files/authentication_milter.in
+++ b/mail/p5-Mail-Milter-Authentication/files/authentication_milter.in
@@ -18,72 +18,82 @@
 # authentication_milter_flags="<set as needed>"
 # authentication_milter_prefix="%%ETCDIR%%"
 # authentication_milter_foreground_enable="<default 'NO'>"
-# authentication_milter_user="%%DEFAULT_USER%%"
-# authentication_milter_group="%%DEFAULT_GROUP%%"
 #
 
 . /etc/rc.subr
 
 name="authentication_milter"
 rcvar="authentication_milter_enable"
+procname="${name}:parent"
 
 load_rc_config $name
 
 : ${authentication_milter_enable:=NO}
 : ${authentication_milter_prefix:=%%ETCDIR%%}
 : ${authentication_milter_foreground_enable:=NO}
-: ${authentication_milter_user:=%%DEFAULT_USER%%}
-: ${authentication_milter_group:=%%DEFAULT_GROUP%%}
 
 pidfile="%%RUNDIR%%/${name}.pid"
-procname="%%PREFIX%%/bin/authentication_milter"
-command_args="--pidfile ${pidfile} --prefix ${authentication_milter_prefix} ${authentication_milter_flags}"
+command="%%PREFIX%%/bin/authentication_milter"
+command_args="--pidfile ${pidfile} --prefix ${authentication_milter_prefix} ${command_args}"
 
-start_cmd="authentication_milter_start"
-start_precmd="authentication_milter_prestart"
-status_cmd="authentication_milter_status"
-stop_cmd="authentication_milter_stop"
+start_precmd="authentication_milter_precmd_start"
+stop_precmd="authentication_milter_precmd"
 
-authentication_milter_prestart () {
+authentication_milter_precmd_start () {
+	var1=
+	var2=
+
 	case "${authentication_milter_flags}" in
 	-c*|*-c*|--control*|*--control*)
-		err 1 "authentication_milter_flags doesn't require --control option."
+		var1="control"
 		;;
 	-d*|*-d*|--daemon*|*--daemon*)
-		err 1 "authentication_milter_flags doesn't require --daemon option."
+		var1="daemon"
 		;;
 	--pidfile*|*--pidfile*)
-		err 1 "authentication_milter_flags doesn't require --pidfile option."
+		var2="pidfile"
 		;;
 	--prefix*|*--prefix*)
-		err 1 "authentication_milter_flags doesn't require --prefix option."
+		var2="prefix"
 		;;
 	-h*|*-h*|--help*|*--help*)
-		err 1 "authentication_milter_flags doesn't require --help option."
+		var1="help"
 		;;
+	esac
+	case ${var1} in
+	"")	;;
+	*)
+		err 1 "Invalid option --${var1} found in ${name}_flags"
+	;;
+	esac
+	case ${var2} in
+	"")	;;
+	*)
+		err 1 "Invalid option --${var2} found in ${name}_flags." \
+		    "Use \$${name}_${var2} in /etc/rc.conf instead."
+	;;
 	esac
 
 	piddir=$(dirname "$pidfile")
-	if [ ! -d "$piddir" ]; then
-		install -d -o "$authentication_milter_user" -g "$authentication_milter_group" -m 0755 "$piddir"
+	install -d -m 0755 \
+	    -o "%%DEFAULT_USER%%" \
+	    -g "%%DEFAULT_GROUP%%" \
+	    "$piddir"
+	install -d \
+	    %%VARLIBDIRBASE%%
+	install -d -m 0750 \
+	    -o "%%DEFAULT_USER%%" \
+	    -g "%%DEFAULT_GROUP%%" \
+	    %%RUNDIR%% %%CACHEDIR%% %%SPOOLDIR%% %%VARLIBDIR%%
+
+	authentication_milter_precmd
+	if ! checkyesno authentication_milter_foreground_enable; then
+		command_args="-d ${command_args}"
 	fi
 }
 
-authentication_milter_start () {
-	if checkyesno authentication_milter_foreground_enable; then
-		${procname}    -c start  ${command_args}
-	else
-		echo "Starting ${name}."
-		${procname} -d -c start  ${command_args}
-	fi
-}
-
-authentication_milter_stop () {
-		${procname}    -c stop   ${command_args}
-}
-
-authentication_milter_status () {
-		${procname}    -c status ${command_args}
+authentication_milter_precmd () {
+	command_args="-c ${rc_arg} ${command_args}"
 }
 
 run_rc_command "$1"

--- a/mail/p5-Mail-Milter-Authentication/files/patch-lib_Mail_Milter_Authentication.pm
+++ b/mail/p5-Mail-Milter-Authentication/files/patch-lib_Mail_Milter_Authentication.pm
@@ -1,0 +1,18 @@
+--- lib/Mail/Milter/Authentication.pm.orig	2024-02-05 02:41:57 UTC
++++ lib/Mail/Milter/Authentication.pm
+@@ -32,11 +32,14 @@ use vars qw(@ISA);
+         my $MYARGS = {
+             'ident' => $Mail::Milter::Authentication::Config::IDENT,
+             'to_stderr' => 0, # handled elsewhere
++            'to_stdout' => 0, # handled elsewhere
+             'log_pid' => 1,
+             'facility' => LOG_MAIL,
+         };
+         if ( exists $config->{ 'log_dispatchouli' } ) {
+-            $MYARGS = $config->{ 'log_dispatchouli' };
++            foreach my $k (keys %{$config->{ 'log_dispatchouli' }}) {
++                $MYARGS->{$k} = $config->{ 'log_dispatchouli' }->{$k};
++            }
+         }
+ 
+         $LOGGER = Log::Dispatchouli->new( $MYARGS );

--- a/mail/p5-Mail-Milter-Authentication/files/patch-share_authentication__milter.json
+++ b/mail/p5-Mail-Milter-Authentication/files/patch-share_authentication__milter.json
@@ -5,7 +5,7 @@
      "dryrun"    : 0,
      "logtoerr"  : 0,
 -    "error_log" : "/var/log/authentication_milter.err",
-+    "error_log" : "%%LOGDIR%%/authentication_milter.err",
++    "log_dispatchouli" : {},
  
 -    "connection"             : "inet:12345@localhost",
 -    "umask"                  : "0000",

--- a/mail/p5-Mail-Milter-Authentication/pkg-plist
+++ b/mail/p5-Mail-Milter-Authentication/pkg-plist
@@ -125,9 +125,4 @@ bin/authentication_milter_client
 %%PERL5_MAN3%%/Mail::Milter::Authentication::Resolver.3.gz
 %%PERL5_MAN3%%/Mail::Milter::Authentication::Tester::HandlerTester.3.gz
 %%PERL5_MAN3%%/Mail::Milter::Authentication::Tester.3.gz
-@dir /var/lib
-@dir(%%DEFAULT_USER%%,%%DEFAULT_GROUP%%,0750) %%RUNDIR%%
-@dir(%%DEFAULT_USER%%,%%DEFAULT_GROUP%%,0750) %%CACHEDIR%%
-@dir(%%DEFAULT_USER%%,%%DEFAULT_GROUP%%,0750) %%SPOOLDIR%%
-@dir(%%DEFAULT_USER%%,%%DEFAULT_GROUP%%,0750) %%VARLIBDIR%%
 @dir %%ETCDIR%%/authentication_milter.d


### PR DESCRIPTION
Functions:

- Use log_dispatchouli instead of error_log in authentication__milter.json. /var/log/maillog is the default log file.
- Fix $MYARGS for Log::Dispatchouli to make the default args work.

Style:

- Use shebangfix to fix "#!env perl" in PREFIX/bin/authentication_milter*.
- Use EXTRACT_AFTER_ARGS instead of using rm(1) in the post-extract target.
- Simplify SUB_LIST using "for".
- Simplify post-patch using ${REINPLACE_ARGS}.
- Create runtime directories such as CACHEDIR in the rc.d script, not the package.

Fixes in the rc.d script:

- Do not use ${name}_user and ${name}_group because the authentication_milter switches the user and the group by itself.
- Simplify precmd for "start".  It now creates the runtime directories.
- Remove the [ -d conditional.  install(8) works even if the directory exists.
- Define $procname properly.
- Remove a_m_stop and a_m_start.  The rc.d framework works fine.